### PR TITLE
Replace non-existent wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ _Have a project or resource you'd like to add? Submit a [pull request](https://g
 ## Projects Using marimo
 
 - [marimo agents](https://github.com/marimo-team/marimo/issues/3916) - Using agents in marimo.
-- [marimo on mutable.ai](https://mutable.ai/marimo-team/marimo) - An AI-generated wiki of the marimo codebase, with chat support.
+- [marimo on deepwiki.com](https://deepwiki.com/marimo-team/marimo) - An AI-generated wiki of the marimo codebase, with chat support.
 - [marimo Guru](https://gurubase.io/g/marimo) - Chat with the marimo docs and codebase.
 - [alhazen](https://github.com/chanzuckerberg/alhazen) - AI agents + toolkits for scientific knowledge, with dashboard visualizations in marimo.
 - [cvxrisk](https://www.cvxgrp.org/cvxrisk/book/docs/index.html) - Compile risk with CVXPY, with marimo notebooks as examples.


### PR DESCRIPTION
Replace the mutable.ai generated wiki content with deepwiki marimo wiki webpage

- [x] I have read and followed the [Contributing Guide](https://github.com/marimo-team/awesome-marimo/blob/main/.github/contributing.md)
